### PR TITLE
libcryptfs-tpm2: exit with error code 200 if tcti is not ready

### DIFF
--- a/src/lib/init.c
+++ b/src/lib/init.c
@@ -108,7 +108,7 @@ libcryptfs_tpm2_init(void)
 
 	rc = init_tcti_context();
 	if (rc != TSS2_RC_SUCCESS)
-		return;
+		exit(200);
 
 	init_sys_context();
 }


### PR DESCRIPTION
Signed-off-by: Lans Zhang <jia.zhang@windriver.com>